### PR TITLE
add code coverage with codecov

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,6 +1,0 @@
-FROM mhart/alpine-node:11.3.0
-WORKDIR /src
-COPY package.json ./
-RUN npm i
-COPY index.js test.js ./
-RUN npm run test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,27 @@
 version: 2
 jobs:
   build:
-    machine: true
+    working_directory: ~/repo
+
+    docker:
+      # Node.js 6 EOL 2019-04-01
+      - image: circleci/node:6
+
     steps:
+      
       - checkout
-      - run: docker build -f .circleci/Dockerfile .
+
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+
+      - run: yarn install
+
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
+
+      - run: yarn test
+
+      # requires CODECOV_TOKEN env var to be set
+      - run: yarn run upload-codecov

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Arg [![CircleCI](https://circleci.com/gh/zeit/arg.svg?style=svg)](https://circleci.com/gh/zeit/arg)
+# Arg [![CircleCI](https://circleci.com/gh/zeit/arg.svg?style=svg)](https://circleci.com/gh/zeit/arg) ![codecov](https://codecov.io/gh/zeit/arg/branch/master/graph/badge.svg)
 
 `arg` is yet another command line option parser.
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   ],
   "scripts": {
     "pretest": "xo",
-    "test": "WARN_EXIT=1 jest --coverage -w 2"
+    "test": "WARN_EXIT=1 jest --coverage -w 2",
+    "upload-codecov": "codecov"
   },
   "xo": {
     "rules": {
@@ -23,6 +24,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.1",
+    "codecov": "^3.2.0",
     "jest": "^20.0.4",
     "xo": "^0.18.2"
   }


### PR DESCRIPTION
fixes https://github.com/zeit/arg/issues/37

I had some difficulties getting codecov to work with the existing
circleci config.  Wasn't really sure why a Docker build was being
done, didn't seem to need to be.  And ... a Docker image was being
built but not actually run?  Not sure what was going on there.

So, I copied from the following circleci config instead:

- https://github.com/zeit/dns-cached-resolve/blob/master/.circleci/config.yml

To enable the codecov bits to work:

- the GH repo will need to be set up in codecov.io
- this will create a token to be used when uploading the codecov file(s)
- that token should be added as an env var in circleci named CODECOV_TOKEN
- voilà, should work