### PR TITLE
Make typings  more type-friendly

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,23 @@
 declare const flagSymbol: unique symbol;
 
 declare function arg<T extends arg.Spec>(
-	spec: T,
+	spec: arg.SpecToMap<T>,
 	options?: arg.Options
 ): arg.Result<T>;
 
 declare namespace arg {
+	type AddDashesToArg<T> = T extends string
+		? `--${T}`
+		: T extends `--${infer K}`
+		? K
+		: never;
+
+	type SpecToMap<T> = T extends arg.Spec
+		? {
+				[K in keyof T as AddDashesToArg<T>]: T[K];
+		  }
+		: never;
+
 	export function flag<T>(fn: T): T & { [flagSymbol]: true };
 
 	export const COUNT: Handler<number> & { [flagSymbol]: true };


### PR DESCRIPTION
This PR is basically a small modification to the typings of this package, I basically added 2 new types to help TypeScript users define the arg specification more clearly.

Right now, you would need to define an interface prefixed with `--` which is not common at all when writing interfaces:

```ts
import arg from 'arg';

interface CliArgs extends arg.Spec {
  '--key': string;
}

arg<CliArgs>({
  // Success!
  '--key': String
});
```

In this PR, this basically converts all the keys from the `T` generic from the default exports prefixed with dashes:
```ts
import arg from 'arg';

interface CliArgs extends arg.Spec {
  key: string;
}

arg<CliArgs>({
  // Success!
  '--key': String
});
```

Right now, this PR only checks for `--`, not single `-` which will be in the next commit.

Sorry for the bad writing, I'm not really good at explaining what I did within PRs (since I'm not usually a contributor on most repositories.)