### PR TITLE
Remove aliases from being suggested in result

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ declare namespace arg {
 	}
 
 	export type Result<T extends Spec> = { _: string[] } & {
-		[K in keyof T]?: T[K] extends Handler
+		[K in keyof T as T[K] extends string ? never : K]?: T[K] extends Handler
 			? ReturnType<T[K]>
 			: T[K] extends [Handler]
 			? Array<ReturnType<T[K][0]>>


### PR DESCRIPTION
This uses [key remapping](https://www.typescriptlang.org/docs/handbook/2/mapped-types.html#key-remapping-via-as) in TypeScript to eliminate aliases from being in the result.

A small change, but helps future users work with this package a lot faster.

I think a video will best explain what this PR does:

https://user-images.githubusercontent.com/65373746/173261069-129f71ec-492c-44a8-ae26-18d0c6644168.mov


